### PR TITLE
Fix TypeScript errors for Netlify deployment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@tanstack/react-query-devtools": "^5.83.0",
+        "@types/node": "^24.1.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/styled-components": "^5.1.34",
@@ -589,6 +590,16 @@
       "version": "7.0.15",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2561,6 +2572,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.83.0",
+    "@types/node": "^24.1.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/styled-components": "^5.1.34",

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,0 +1,5 @@
+declare var process: {
+  env: {
+    [key: string]: string | undefined;
+  };
+}; 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    
+    /* Types */
+    "types": ["node"],
 
     /* Path mapping */
     "baseUrl": ".",


### PR DESCRIPTION
- Install @types/node as dev dependency
- Add globals.d.ts with process declaration
- Update tsconfig.json to include Node types
- Fixes 'Cannot find name process' errors in apiClient.ts