### PR TITLE
Fix Netlify publish directory path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "frontend"
-  publish = "frontend/dist"
+  publish = "dist"
   command = "npm ci && npm run build"
 
 [build.environment]


### PR DESCRIPTION
- Change publish path from 'frontend/dist' to 'dist' in netlify.toml
- Fixes 'Deploy directory does not exist' error
- Build now correctly points to the generated dist folder